### PR TITLE
Consolidate open and open_create function typedef's

### DIFF
--- a/framework/mock/test_system.cpp
+++ b/framework/mock/test_system.cpp
@@ -188,7 +188,7 @@ test_system *test_system::instance_ = nullptr;
 
 test_system::test_system() : initialized_(false), root_("") {
   open_ = (open_func)dlsym(RTLD_NEXT, "open");
-  open_create_ = (open_create_func)open_;
+  open_create_ = open_;
   read_ = (read_func)dlsym(RTLD_NEXT, "read");
   fopen_ = (fopen_func)dlsym(RTLD_NEXT, "fopen");
   popen_ = (popen_func)dlsym(RTLD_NEXT, "popen");

--- a/framework/mock/test_system.h
+++ b/framework/mock/test_system.h
@@ -178,8 +178,7 @@ class test_system {
   std::map<FILE * , std::string> popen_requests_;
   static test_system *instance_;
 
-  typedef int (*open_func)(const char *pathname, int flags);
-  typedef int (*open_create_func)(const char *pathname, int flags, mode_t mode);
+  typedef int (*open_func)(const char *pathname, int flags, ...);
   typedef ssize_t (*read_func)(int fd, void *buf, size_t count);
   typedef FILE * (*fopen_func)(const char *path, const char *mode);
   typedef FILE * (*popen_func)(const char *cmd, const char *type);
@@ -201,7 +200,7 @@ class test_system {
                            glob_t *pglob);
 
   open_func open_;
-  open_create_func open_create_;
+  open_func open_create_;
   read_func read_;
   fopen_func fopen_;
   popen_func popen_;


### PR DESCRIPTION
The open() function is defined as a variac function
int open(const char *, int, ...)
here
https://pubs.opengroup.org/onlinepubs/009695399/functions/open.html

So it is not necessary to have two typedefs.

Fixes this compile error on RHEL 8.2 + gcc 8.3

.../opae-sdk/external/opae-test/framework/mock/test_system.cpp: In constructor ‘opae::testing::test_system::test_system()’:
.../opae-sdk/external/opae-test/framework/mock/test_system.cpp:191:36: error: cast between incompatible function types from ‘opae::testing::test_system::open_func’ {aka ‘int (*)(const char*, int)’} to ‘opae::testing::test_system::open_create_func’ {aka ‘int (*)(const char*, int, unsigned int)’} [-Werror=cast-function-type]

Signed-off-by: Tom Rix <trix@redhat.com>