### PR TITLE
mock: set char dev mode when path rooted at /dev

### DIFF
--- a/framework/mock/test_system.cpp
+++ b/framework/mock/test_system.cpp
@@ -646,12 +646,30 @@ ssize_t test_system::readlink(const char *path, char *buf, size_t bufsize) {
 
 int test_system::xstat(int ver, const char *path, struct stat *buf) {
   std::string syspath = get_sysfs_path(path);
-  return xstat_(ver, syspath.c_str(), buf);
+  int res = xstat_(ver, syspath.c_str(), buf);
+
+  if (!res && strlen(path) > 5) {
+    // If path is rooted at /dev, assume it is a char device.
+    str::string p(path, 5);
+    if (p == std::string("/dev/"))
+	    buf->st_mode |= S_IFCHR;
+  }
+
+  return res;
 }
 
 int test_system::lstat(int ver, const char *path, struct stat *buf) {
   std::string syspath = get_sysfs_path(path);
-  return lstat_(ver, syspath.c_str(), buf);
+  int res = lstat_(ver, syspath.c_str(), buf);
+
+  if (!res && strlen(path) > 5) {
+    // If path is rooted at /dev, assume it is a char device.
+    str::string p(path, 5);
+    if (p == std::string("/dev/"))
+	    buf->st_mode |= S_IFCHR;
+  }
+
+  return res;
 }
 
 int test_system::scandir(const char *dirp, struct dirent ***namelist,

--- a/framework/mock/test_system.cpp
+++ b/framework/mock/test_system.cpp
@@ -651,8 +651,10 @@ int test_system::xstat(int ver, const char *path, struct stat *buf) {
   if (!res && strlen(path) > 5) {
     // If path is rooted at /dev, assume it is a char device.
     str::string p(path, 5);
-    if (p == std::string("/dev/"))
-	    buf->st_mode |= S_IFCHR;
+    if (p == std::string("/dev/")) {
+            buf->st_mode &= ~S_IFMT;
+            buf->st_mode |= S_IFCHR;
+    }
   }
 
   return res;
@@ -665,8 +667,10 @@ int test_system::lstat(int ver, const char *path, struct stat *buf) {
   if (!res && strlen(path) > 5) {
     // If path is rooted at /dev, assume it is a char device.
     str::string p(path, 5);
-    if (p == std::string("/dev/"))
-	    buf->st_mode |= S_IFCHR;
+    if (p == std::string("/dev/")) {
+            buf->st_mode &= ~S_IFMT;
+            buf->st_mode |= S_IFCHR;
+    }
   }
 
   return res;


### PR DESCRIPTION
Make sure that statbuf->st_mode has S_IFCHR set when the path is
rooted at /dev.