### PR TITLE
Stub in support for dcp-vc-dfl0

### DIFF
--- a/framework/platform/fpga_hw.cpp
+++ b/framework/platform/fpga_hw.cpp
@@ -309,6 +309,32 @@ static platform_db MOCK_PLATFORMS = {
                        .fme_num_errors = 9,
                        .port_num_errors = 3,
                        .gbs_guid = "58656f6e-4650-4741-b747-425376303031",
+                       .mdata = vc_mdata}}}},
+   {"dcp-vc-dfl0",
+     test_platform{.mock_sysfs = "",
+                   .driver = fpga_driver::linux_dfl0,
+                   .devices = {test_device{
+                       .fme_guid = "CF9B1C50-37C9-45E9-8030-F921B17D2B3A",
+                       .afu_guid = "9AEFFE5F-8457-0612-C000-C9660D824272",
+                       .segment = 0x0,
+                       .bus = 0x05,
+                       .device = 0,
+                       .function = 0,
+                       .num_vfs = 0,
+                       .socket_id = 0,
+                       .num_slots = 1,
+                       .bbs_id = 0x222000200567bd1,
+                       .bbs_version = {2, 2, 2},
+                       .state = FPGA_ACCELERATOR_UNASSIGNED,
+                       .num_mmio = 0x2,
+                       .num_interrupts = 0,
+                       .fme_object_id = 0xf500000,
+                       .port_object_id = 0xf400000,
+                       .vendor_id = 0x8086,
+                       .device_id = 0x0b30,
+                       .fme_num_errors = 9,
+                       .port_num_errors = 3,
+                       .gbs_guid = "58656f6e-4650-4741-b747-425376303031",
                        .mdata = vc_mdata}}}}
 };
 
@@ -613,7 +639,8 @@ static std::map<platform_cfg, std::string> platform_names = {
   {  platform_cfg(0x8086, 0x09c4, fpga_driver::linux_dfl0), "dcp-rc-dfl0_patchset2" },
   {  platform_cfg(0x8086, 0xbcc0, fpga_driver::linux_dfl0),  "skx-p-dfl0" },
   {  platform_cfg(0x8086, 0x0b30, fpga_driver::linux_intel), "dcp-vc" },
-  {  platform_cfg(0x8086, 0x0b31, fpga_driver::linux_intel), "dcp-vc-v" }
+  {  platform_cfg(0x8086, 0x0b31, fpga_driver::linux_intel), "dcp-vc-v" },
+  {  platform_cfg(0x8086, 0x0b30, fpga_driver::linux_dfl0), "dcp-vc-dfl0" },
   
 };
 


### PR DESCRIPTION
From looking at the skx-p vs skx-p-dfl0, there are very few differences.

-    {"skx-p",
-     test_platform{.mock_sysfs = "mock_sys_tmp-1socket-nlb0.tar.gz",
-                   .driver = fpga_driver::linux_intel,
+   {"skx-p-dfl0",
+     test_platform{.mock_sysfs = "mock_sys_tmp-dfl0-nlb0.tar.gz",
+                   .driver = fpga_driver::linux_dfl0,

So to stub in dcp-vc-dfl0 support, copy the dcp-vc entry and
change the driver interface.  Because at this time the sysfs does
not exist, set the mock_sysfs entry to an empty string.

Signed-off-by: Tom Rix <trix@redhat.com>