### PR TITLE
Fix pci path generation.

### DIFF
--- a/framework/platform/fpga_hw.cpp
+++ b/framework/platform/fpga_hw.cpp
@@ -533,7 +533,7 @@ static T parse_file_int(const std::string &path) {
 
 static std::string make_path(int seg, int bus, int dev, int func){
     std::stringstream num;
-    num << std::setw(2) << std::hex << bus; 
+    num << std::setw(2) << std::setfill('0') << std::hex << bus;
     std::string b (num.str());
     num.clear();
     num.str(std::string());


### PR DESCRIPTION
Tests having the message

FPGA Not found.
WARNING: stat::No such file or directory

Was traced back to generation of the pci sysfs path.
An example of path before
/sys/bus/pci/devices/0000: 6:00.0/fpga*/*/*fme.*/socket_id

Problem is the space ': 6:' in the bus field.

So zero fill as the other strings.

Signed-off-by: Tom Rix <trix@redhat.com>