### PR TITLE
tests: add test_opae.py

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,3 +29,7 @@ cmake_minimum_required(VERSION 2.8.12)
 project(opae-test)
 
 add_subdirectory(framework)
+
+configure_file(test_opae.py
+    ${CMAKE_BINARY_DIR}/test_opae.py
+    )

--- a/test_opae.py
+++ b/test_opae.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# vim:fenc=utf-8
+# Copyright(c) 2020, Intel Corporation
+#
+# Redistribution  and  use  in source  and  binary  forms,  with  or  without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of  source code  must retain the  above copyright notice,
+#   this list of conditions and the following disclaimer.
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+# * Neither the name  of Intel Corporation  nor the names of its contributors
+#   may be used to  endorse or promote  products derived  from this  software
+#   without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,  BUT NOT LIMITED TO,  THE
+# IMPLIED WARRANTIES OF  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED.  IN NO EVENT  SHALL THE COPYRIGHT OWNER  OR CONTRIBUTORS BE
+# LIABLE  FOR  ANY  DIRECT,  INDIRECT,  INCIDENTAL,  SPECIAL,  EXEMPLARY,  OR
+# CONSEQUENTIAL  DAMAGES  (INCLUDING,  BUT  NOT LIMITED  TO,  PROCUREMENT  OF
+# SUBSTITUTE GOODS OR SERVICES;  LOSS OF USE,  DATA, OR PROFITS;  OR BUSINESS
+# INTERRUPTION)  HOWEVER CAUSED  AND ON ANY THEORY  OF LIABILITY,  WHETHER IN
+# CONTRACT,  STRICT LIABILITY,  OR TORT  (INCLUDING NEGLIGENCE  OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+import pytest
+import subprocess
+
+from pathlib import Path
+
+
+def get_gtests():
+    for f in sorted(Path("bin").glob("test_*")):
+        if f.stem != 'test_pyopae':
+            test_bin = str(f)
+            yield test_bin
+
+
+def get_pytests():
+    for f in sorted(Path().glob("test_*.py")):
+        yield str(f)
+
+
+@pytest.mark.parametrize(
+    'test_exec', list(get_gtests())
+)
+def test_opae(test_exec):
+    subprocess.run([test_exec])
+
+
+@pytest.mark.parametrize(
+    'test_py', list(get_pytests())
+)
+def test_pyopae(test_py):
+    subprocess.run(['./bin/test_pyopae', 'test', test_py])


### PR DESCRIPTION
This is a pytest file to run google test binaries.
This is intended for CI and expected to run in the build directory.
It will look in bin for test_* files and execute them
(with the exception of test_pyopae).
For test_pyopae, it looks in the build directory for test_*.py and runs
those with test_pyopae.